### PR TITLE
Feature/swing view

### DIFF
--- a/src/main/java/dev/justgiulio/passwordmanager/view/AccountView.java
+++ b/src/main/java/dev/justgiulio/passwordmanager/view/AccountView.java
@@ -16,5 +16,7 @@ public interface AccountView {
 	void accountIsDeleted();
 	
 	void passwordIsGenereated(String generatedPassword);
+	
+	void showAccountRelatedError(String string);
 
 }

--- a/src/main/java/dev/justgiulio/passwordmanager/view/swing/AccountSwingView.java
+++ b/src/main/java/dev/justgiulio/passwordmanager/view/swing/AccountSwingView.java
@@ -682,6 +682,15 @@ public class AccountSwingView extends javax.swing.JFrame implements AccountView 
 	public void passwordIsGenereated(String generatedPassword) {
 		SwingUtilities.invokeLater(() -> textFieldGeneratedPassword.setText(generatedPassword));
 	}
+	
+	@Override
+	public void showAccountRelatedError(String string) {
+		SwingUtilities.invokeLater(() -> {
+			labelOperationResult.setEnabled(true);
+			labelOperationResult.setText(string);
+		});
+		
+	}
 
 	public void setAccountController(AccountController accountController) {
 		this.accountController = accountController;
@@ -707,5 +716,7 @@ public class AccountSwingView extends javax.swing.JFrame implements AccountView 
 			labelAccountAdded.setText("");
 		});
 	}
+
+	
 
 }

--- a/src/test/java/dev/justgiulio/passwordmanager/view/AccountSwingViewTest.java
+++ b/src/test/java/dev/justgiulio/passwordmanager/view/AccountSwingViewTest.java
@@ -291,7 +291,6 @@ public class AccountSwingViewTest extends AssertJSwingJUnitTestCase {
 		accountSwingView.accountIsDeleted();
 		window.label("labelOperationResult").requireEnabled();
 		window.label("labelOperationResult").requireText("Account Deleted!");
-
 	}
 
 	@Test
@@ -479,6 +478,18 @@ public class AccountSwingViewTest extends AssertJSwingJUnitTestCase {
 		verify(accountController).delete(new Account("github.com", new Credential("giulio", "passgiulio")));
 	}
 
+	@Test
+	@GUITest
+	public void testModifyOperationErrorShowLabel() {
+		window.tabbedPane("tabbedPanel").selectTab(1);
+		window.panel("panelDisplayedAccounts").focus();
+		window.label("labelOperationResult").requireDisabled();
+		window.label("labelOperationResult").requireText("");
+		accountSwingView.showAccountRelatedError("Generic Error");
+		window.label("labelOperationResult").requireEnabled();
+		window.label("labelOperationResult").requireText("Generic Error");
+	}
+	
 	private void resetInputTextAccountCredential() {
 		window.textBox("textFieldSiteName").deleteText();
 		window.textBox("textFieldUsername").deleteText();


### PR DESCRIPTION
Implement new method:
-showAccountRelatedError

I realized that no errors are showed in labelOperationResult, mostly for modify operations.
Implement this new method to change the current way of showing errors for modify operations.

This change affects AccountController too
