### PR TITLE
Travis, include e2e build only on PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
     - jdk: openjdk8
       if: type IN (pull_request)
       env: MAVEN_ARGS="-Ppit"
+    - jdk: openjdk8
+      if: type IN (pull_request)
+      env: MAVEN_ARGS="-Pe2e"
 
 services:
   - docker


### PR DESCRIPTION
Include E2E job inside travis matrix, the execution of this job is permitted when a PR is submitted