### PR TITLE
Fix, refactor save method on AccountRedisRepository

### DIFF
--- a/src/main/java/dev/justgiulio/passwordmanager/repository/AccountRedisRepository.java
+++ b/src/main/java/dev/justgiulio/passwordmanager/repository/AccountRedisRepository.java
@@ -52,10 +52,10 @@ public class AccountRedisRepository implements AccountRepository {
 	}
 	
 	@Override
-	public String save(Account accountToSave) {
+	public Long save(Account accountToSave) {
 		Map<String, String> mapToSave = new HashMap<>();
 		mapToSave.put(accountToSave.getCredential().getUsername(), accountToSave.getCredential().getPassword());
-		return this.client.hmset(accountToSave.getSite(), mapToSave);
+		return this.client.hset(accountToSave.getSite(), mapToSave);
 	}
 	
 	@Override

--- a/src/main/java/dev/justgiulio/passwordmanager/repository/AccountRepository.java
+++ b/src/main/java/dev/justgiulio/passwordmanager/repository/AccountRepository.java
@@ -14,7 +14,7 @@ public interface AccountRepository {
 
 	List<Account> findByPassword(String password);
 
-	String save(Account accountToSave);
+	Long save(Account accountToSave);
 
 	void delete(Account account);
 

--- a/src/test/java/dev/justgiulio/passwordmanager/repository/AccountRepositoryRedistTest.java
+++ b/src/test/java/dev/justgiulio/passwordmanager/repository/AccountRepositoryRedistTest.java
@@ -196,10 +196,10 @@ public class AccountRepositoryRedistTest {
 	 */
 	@Test
 	public void testSaveAccountWhenDatabaseIsEmpty() {
-		String result = accountRedisRepository.save(new Account("github",new Credential("giulio","passgiulio")));
+		Long result = accountRedisRepository.save(new Account("github",new Credential("giulio","passgiulio")));
 		ListAssert<Account> assertThatList = assertThat(accountRedisRepository.findAll());
 		assertThatList.containsExactly(new Account("github",new Credential("giulio","passgiulio")));
-		assertThat(result).isEqualTo("OK");
+		assertThat(result).isEqualTo(1);
 	}
 	
 	@Test
@@ -210,10 +210,10 @@ public class AccountRepositoryRedistTest {
 		savedAccounts.add(githubAccount);
 		savedAccounts.add(gitlabAccount);
 		addAccountToRedisDatabase(githubAccount);
-		String result = accountRedisRepository.save(gitlabAccount);
+		Long result = accountRedisRepository.save(gitlabAccount);
 		ListAssert<Account> assertThatList = assertThat(accountRedisRepository.findAll());
 		assertThatList.containsAll(savedAccounts);
-		assertThat(result).isEqualTo("OK");
+		assertThat(result).isEqualTo(1);
 	}
 	
 	@Test
@@ -223,12 +223,12 @@ public class AccountRepositoryRedistTest {
 		List<Account> savedAccounts = new ArrayList<>();
 		savedAccounts.add(githubAccount);
 		savedAccounts.add(gitlabAccount);
-		String resultGithub = accountRedisRepository.save(githubAccount);
-		String resultGitlab = accountRedisRepository.save(gitlabAccount);
+		Long resultGithub = accountRedisRepository.save(githubAccount);
+		Long resultGitlab = accountRedisRepository.save(gitlabAccount);
 		ListAssert<Account> assertThatList = assertThat(accountRedisRepository.findAll());
 		assertThatList.containsAll(savedAccounts);
-		assertThat(resultGithub).isEqualTo("OK");
-		assertThat(resultGitlab).isEqualTo("OK");
+		assertThat(resultGithub).isEqualTo(1);
+		assertThat(resultGitlab).isEqualTo(1);
 	}
 	
 	@Test


### PR DESCRIPTION
Save method now use hset instead hmset
This refactor is needed because from version 4 of Redis hmset is deprecated in favour of hset.
HSET return number added fields instead result status.

Reference:
https://redis.io/commands/hset
https://redis.io/commands/hmset